### PR TITLE
Expose SSEClient

### DIFF
--- a/lib/sse.js
+++ b/lib/sse.js
@@ -31,14 +31,10 @@ function SSE(httpServer, options) {
 util.inherits(SSE, events.EventEmitter);
 
 SSE.prototype.handleRequest = function(req, res) {
-  req.socket.setNoDelay(true);
-  var isLegacy = req.headers['user-agent'] && (/^Opera[^\/]*\/9/).test(req.headers['user-agent']);
-  if (isLegacy) {
-    res.writeHead(200, {'Content-Type': 'text/x-dom-event-stream'});
-  }
-  else res.writeHead(200, {'Content-Type': 'text/event-stream'});
-  res.write(':ok\n\n');
-  this.emit('connection', new SSEClient(req, res, isLegacy));
+  var client = new SSEClient(req, res);
+  client.initialize();
+  this.emit('connection', client);
 }
 
 module.exports = SSE;
+module.exports.Client = SSEClient;

--- a/lib/sseclient.js
+++ b/lib/sseclient.js
@@ -1,10 +1,10 @@
 var util = require('util')
   , events = require('events');
 
-function SSEClient(req, res, isLegacy) {
+function SSEClient(req, res) {
   this.req = req;
   this.res = res;
-  this.isLegacy = isLegacy;
+  this.isLegacy = req.headers['user-agent'] && (/^Opera[^\/]*\/9/).test(req.headers['user-agent']);
   var self = this;
   res.on('close', function() {
     self.emit('close');
@@ -16,6 +16,15 @@ function SSEClient(req, res, isLegacy) {
  */
 
 util.inherits(SSEClient, events.EventEmitter);
+
+SSEClient.prototype.initialize = function() {
+  this.req.socket.setNoDelay(true);
+  if (this.isLegacy) {
+    this.res.writeHead(200, {'Content-Type': 'text/x-dom-event-stream'});
+  }
+  else this.res.writeHead(200, {'Content-Type': 'text/event-stream'});
+  this.res.write(':ok\n\n');
+};
 
 SSEClient.prototype.send = function(event, data, id) {
   if (arguments.length == 0) return;

--- a/test/sse.test.js
+++ b/test/sse.test.js
@@ -118,6 +118,24 @@ describe('SSE', function() {
   });
 
   describe('client', function() {
+    it('is exported', function(done) {
+      expect(SSE.Client);
+
+      var server = listen(++port, function() {
+        var sse = new SSE(server);
+        sse.on('connection', function(client) {
+          expect(client instanceof SSE.Client);
+          client.on('close', function() {
+            server.close();
+            done();
+          });
+        });
+      });
+      request('http://localhost:' + port + '/sse', function(res) {
+        res.socket.end();
+      });
+    });
+
     describe('emits', function() {
       it('a "close" event when a client connects', function(done) {
         var server = listen(++port, function() {


### PR DESCRIPTION
I need to be able to create an SSEClient in the actual request handlers so I can retrieve info from the `req`, etc.  For example:

``` javascript
var SSE = require('sse');
var express = require('express');

var app = express();

app.get('/events/:id', function(req, res) {
  findById(req.params.id, function(err, obj) {
    if (err) ...;

    var client = new SSE.Client(req, res);
    client.initialize();

    obj.on('foo', function(foo) {
      client.send(foo, 'foo');
    });

    ...
  });
});
```
