### PR TITLE
Added support for retry

### DIFF
--- a/lib/sse.js
+++ b/lib/sse.js
@@ -5,8 +5,8 @@ var Options = require('options')
 
 function SSE(httpServer, options) {
   options = new Options({
-    path: '/sse',
-    verifyRequest: null
+    path          : '/sse',
+    verifyRequest : null
   }).merge(options);
   this.server = httpServer;
   var oldListeners = this.server.listeners('request');

--- a/lib/sseclient.js
+++ b/lib/sseclient.js
@@ -1,5 +1,15 @@
-var util = require('util')
-  , events = require('events');
+var util    = require('util'), 
+    events  = require('events');
+
+
+
+// Check too see if if a value is an Object
+
+function isObject(value) { 
+  return value instanceof Object;
+}
+
+
 
 function SSEClient(req, res) {
   this.req = req;
@@ -10,9 +20,9 @@ function SSEClient(req, res) {
   });
 }
 
-/**
- * Inherits from EventEmitter.
- */
+
+
+// Inherits from EventEmitter.
 
 util.inherits(SSEClient, events.EventEmitter);
 
@@ -25,25 +35,67 @@ SSEClient.prototype.initialize = function() {
   this.res.write(':ok\n\n');
 };
 
+
+
+// Send method
+
 SSEClient.prototype.send = function(event, data, id) {
-  if (arguments.length == 0) return;
-  if (arguments.length == 1) {
-    data = event;
-    event = null;
+
+  if (arguments.length === 0) {
+    return;
   }
-  if (typeof event !== 'undefined' && event !== null) this.res.write('event:' + event + '\n');
-  if (typeof id !== 'undefined' && event !== null) this.res.write('id:' + id + '\n');
-  data = data.replace(/(\r\n|\r|\n)/g, '\n');
-  var dataLines = data.split(/\n/);
+
+  var senderObject = {
+    event : event || undefined, 
+    data  : data || undefined, 
+    id    : id || undefined, 
+    retry : undefined
+  };
+
+  if (isObject(event)) {
+    senderObject.event   = event.event || undefined, 
+    senderObject.data    = event.data || undefined, 
+    senderObject.id      = event.id || undefined, 
+    senderObject.retry   = event.retry || undefined
+  }
+
+  if (!isObject(event) && arguments.length === 1) {    
+    senderObject.event   = undefined;
+    senderObject.data    = event;
+  }
+  
+
+  if (senderObject.event) {
+    this.res.write('event:' + senderObject.event + '\n');
+  } 
+
+  if (senderObject.retry) {
+    this.res.write('retry:' + senderObject.retry + '\n');
+  }
+
+  if (senderObject.id) {
+    this.res.write('id:' + senderObject.id + '\n');
+  } 
+
+
+  senderObject.data = senderObject.data.replace(/(\r\n|\r|\n)/g, '\n');
+  var dataLines = senderObject.data.split(/\n/);
+
   for (var i = 0, l = dataLines.length; i < l; ++i) {
     var line = dataLines[i];
+
     if ((l-1) === 0) {
       this.res.write('data: ' + line + '\n\n');
     } else {
       this.res.write('data: ' + line + '\n');
     }
   }
+
 }
+
+
+
+// Close method
 
 SSEClient.prototype.close = function() {
   this.res.end();


### PR DESCRIPTION
The [SSE spec has a retry method](http://dev.w3.org/html5/eventsource/#event-stream-interpretation) that makes it possible to adjust how often a client should try to re-connect to the server if the client disconnects. 

This can be set for each message that is sent and the client will use the last set value when the client goes offline.

Due to the fact that this is set on each message it could potentially introduce a new function attribute on the client send method like this:

``` js
client.send(event, data, id, retry);
```

Event, id and retry is not mandatory in a Event so the respective attributes are therefor not mandatory in the client method. Having all these none mandatory attributes would make it kinda messy to handle the different scenarios where one attributes is provided and not another. To deal with this I have added support for providing _one_ object with the different values to the send method instead of letting the send method have four attributes.

In other words; one can now do the following:

``` js
client.send({event : 'foo', data : 'bar', id : 1, retry : 10000});
```

Or if one just want to set the retry:

``` js
client.send({data : 'bar', retry : 10000});
```

The send method are still able to receive values on event, data and id attributes as before too not break existing implementations. Retry is not added to this, it is only added to the object one can pass. If the first attribute to the send method is an object the data and id attribute will be ignored.
