### PR TITLE
Specify versions of dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,11 +20,11 @@
     "test": "node_modules/.bin/mocha"
   },
   "dependencies": {
-    "options": "latest"
+    "options": "0.0.6"
   },
   "devDependencies": {
-    "mocha": "latest",
-    "expect.js": "latest"
+    "mocha": "^3.0.2",
+    "expect.js": "^0.3.1"
   },
   "optionalDependencies": {}
 }


### PR DESCRIPTION
Due to a `npm shrinkwrap` bug, `latest` is not well recognized:

```
npm ERR! invalid: have options@0.0.6 (expected: latest) /Users/loicmahieu/Projects/iGLOO/foldio-app/api/node_modules/sse/node_modules/options
```

Anyway it better to specify versions instead of `distTags`.
