### PR TITLE
Add options parameter and allow setting of extra response headers

### DIFF
--- a/lib/sseclient.js
+++ b/lib/sseclient.js
@@ -3,9 +3,25 @@ var util    = require('util'),
 
 module.exports = SSEClient;
 
-function SSEClient(req, res) {
+/**
+ * @param {http.ClientRequest}  req
+ * @param {http.ServerResponse} res
+ * @param {Object} options
+ * @param {Object} options.headers: Extra headers to add to the SSE response.
+ *                 The defaults are: {
+ *                   'Content-Type': 'text/event-stream',
+ *                   'Cache-Control': 'no-cache',
+ *                   'Connection': 'keep-alive'
+ *                 }
+ *                 Anything passed in options.headers will be merged over the defaults.
+ *
+ * @constructor
+ */
+function SSEClient(req, res, options) {
   this.req = req;
   this.res = res;
+  this.options = options || {};
+
   var self = this;
   res.on('close', function() {
     self.emit('close');
@@ -14,13 +30,20 @@ function SSEClient(req, res) {
 
 util.inherits(SSEClient, events.EventEmitter);
 
+
 SSEClient.prototype.initialize = function() {
   this.req.socket.setNoDelay(true);
-  this.res.writeHead(200, {
-    'Content-Type': 'text/event-stream',
-    'Cache-Control': 'no-cache',
-    'Connection': 'keep-alive'
-  });
+
+  // Merge extra headers with default ones.
+  var headers = Object.assign({
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      'Connection': 'keep-alive'
+    },
+    this.options.headers
+  );
+
+  this.res.writeHead(200, headers);
   this.res.write(':ok\n\n');
 };
 


### PR DESCRIPTION
I need the ability to set charset to utf-8 in the Content-Type, and
this will allow for more flexible header settings.

See: https://phabricator.wikimedia.org/T154328