### PR TITLE
Add `no-transform` to cache-control header

### DIFF
--- a/lib/sseclient.js
+++ b/lib/sseclient.js
@@ -18,7 +18,7 @@ SSEClient.prototype.initialize = function() {
   this.req.socket.setNoDelay(true);
   this.res.writeHead(200, {
     'Content-Type': 'text/event-stream',
-    'Cache-Control': 'no-cache',
+    'Cache-Control': 'no-cache, no-transform',
     'Connection': 'keep-alive'
   });
   this.res.write(':ok\n\n');

--- a/test/sse.test.js
+++ b/test/sse.test.js
@@ -95,6 +95,16 @@ describe('SSE', function() {
         });
       });
     });
+
+    it('has cache-control set to no-cache, no-transform', function(done) {
+      var server = listen(++port, function() {
+        var sse = new SSE(server);
+        request('http://localhost:' + port + '/sse', function(res) {
+          expect(res.headers['cache-control']).to.equal('no-cache, no-transform');
+          done();
+        });
+      });
+    });
   });
 
   describe('client', function() {


### PR DESCRIPTION
It's an honour to open a PR to this good old package that has helped me a lot over the years, thanks! 😸 

Needed the cache control header to include `no-transform` as a fix for create-react-app webpack setup to not buffer data sent via SSE, but rather proxied immediately.

Can't think of any potential unwanted effects of specifying that these SSE connections should not be transformed in any way either. If anyone sees any issues with that, please let me know.

Refs https://github.com/facebookincubator/create-react-app/issues/1633#issuecomment-291353470