### PR TITLE
Add custom headers option

### DIFF
--- a/lib/sse.js
+++ b/lib/sse.js
@@ -13,18 +13,25 @@ module.exports = SSE;
 module.exports.Client = SSEClient;
 
 function SSE(httpServer, options) {
+  
   options = new Options({
     path          : '/sse',
-    verifyRequest : null
+    verifyRequest : null,
+    headers: {}
   }).merge(options);
+  
   this.server = httpServer;
   var oldListeners = this.server.listeners('request');
   this.server.removeAllListeners('request');
   var self = this;
   this.server.on('request', function(req, res) {
+   
     var u = url.parse(req.url);
     var pathname = u.pathname.replace(/^\/{2,}/, '/');
     if (self.matchesPath(pathname, options.value.path) && (options.value.verifyRequest == null || options.value.verifyRequest(req))) {
+      Object.keys(options.value.headers).forEach(function(key) {
+        res.setHeader(key, options.value.headers[key]);
+      });
       self.handleRequest(req, res, u.query);
     }
     else {
@@ -38,6 +45,7 @@ function SSE(httpServer, options) {
 util.inherits(SSE, events.EventEmitter);
 
 SSE.prototype.handleRequest = function(req, res, query) {
+
   var client = new SSEClient(req, res);
   client.initialize();
   this.emit('connection', client, querystring.parse(query));


### PR DESCRIPTION
Accept custom headers to enable cors the way you want or other headers

Example:

`var sse = new SSE(server, {
  headers: {
    'Access-Control-Allow-Origin': '*',
    "Access-Control-Allow-Headers": "Origin, X-Requested-With, Content-Type, Accept, x-access-token",
    "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS"
  }
});`