### PR TITLE
Improving ottomata's approach to add optional response headers

### DIFF
--- a/lib/sse.js
+++ b/lib/sse.js
@@ -39,7 +39,7 @@ function SSE(httpServer, options) {
 util.inherits(SSE, events.EventEmitter);
 
 SSE.prototype.handleRequest = function(req, res, query, headers) {
-  var client = new SSEClient(req, res, headers);
+  var client = new SSEClient(req, res, {headers: headers});
   client.initialize();
   this.emit('connection', client, querystring.parse(query));
 }

--- a/lib/sse.js
+++ b/lib/sse.js
@@ -15,7 +15,8 @@ module.exports.Client = SSEClient;
 function SSE(httpServer, options) {
   options = new Options({
     path          : '/sse',
-    verifyRequest : null
+    verifyRequest : null,
+    headers: {}
   }).merge(options);
   this.server = httpServer;
   var oldListeners = this.server.listeners('request');
@@ -25,7 +26,7 @@ function SSE(httpServer, options) {
     var u = url.parse(req.url);
     var pathname = u.pathname.replace(/^\/{2,}/, '/');
     if (self.matchesPath(pathname, options.value.path) && (options.value.verifyRequest == null || options.value.verifyRequest(req))) {
-      self.handleRequest(req, res, u.query);
+      self.handleRequest(req, res, u.query, options.value.headers);
     }
     else {
       for (var i = 0, l = oldListeners.length; i < l; ++i) {
@@ -37,8 +38,8 @@ function SSE(httpServer, options) {
 
 util.inherits(SSE, events.EventEmitter);
 
-SSE.prototype.handleRequest = function(req, res, query) {
-  var client = new SSEClient(req, res);
+SSE.prototype.handleRequest = function(req, res, query, headers) {
+  var client = new SSEClient(req, res, headers);
   client.initialize();
   this.emit('connection', client, querystring.parse(query));
 }

--- a/lib/sseclient.js
+++ b/lib/sseclient.js
@@ -1,49 +1,70 @@
-var util    = require('util'),
-    events  = require('events');
+var util = require('util'),
+  events = require('events');
 
 module.exports = SSEClient;
 
-function SSEClient(req, res) {
+
+/**
+ * @param {http.ClientRequest}  req
+ * @param {http.ServerResponse} res
+ * @param {Object} options
+ * @param {Object} options.headers: Extra headers to add to the SSE response.
+ *                 The defaults are: {
+ *                   'Content-Type': 'text/event-stream',
+ *                   'Cache-Control': 'no-cache',
+ *                   'Connection': 'keep-alive'
+ *                 }
+ *                 Anything passed in options.headers will be merged over the defaults.
+ *
+ * @constructor
+ */
+function SSEClient(req, res, options) {
   this.req = req;
   this.res = res;
   var self = this;
-  res.on('close', function() {
+  res.on('close', function () {
     self.emit('close');
   });
 }
 
 util.inherits(SSEClient, events.EventEmitter);
 
-SSEClient.prototype.initialize = function() {
+SSEClient.prototype.initialize = function () {
   this.req.socket.setNoDelay(true);
-  this.res.writeHead(200, {
+
+  // Merge extra headers with default ones.
+  var headers = Object.assign({
     'Content-Type': 'text/event-stream',
-    'Cache-Control': 'no-cache, no-transform',
+    'Cache-Control': 'no-cache',
     'Connection': 'keep-alive'
-  });
+  },
+    this.options.headers
+  );
+
+  this.res.writeHead(200, headers);
   this.res.write(':ok\n\n');
 };
 
-SSEClient.prototype.send = function(event, data, id) {
+SSEClient.prototype.send = function (event, data, id) {
   if (arguments.length === 0) return;
 
   var senderObject = {
-    event : event || undefined,
-    data  : data || undefined,
-    id    : id || undefined,
-    retry : undefined
+    event: event || undefined,
+    data: data || undefined,
+    id: id || undefined,
+    retry: undefined
   };
 
   if (typeof event == 'object') {
-    senderObject.event   = event.event || undefined,
-    senderObject.data    = event.data || undefined,
-    senderObject.id      = event.id || undefined,
-    senderObject.retry   = event.retry || undefined
+    senderObject.event = event.event || undefined,
+      senderObject.data = event.data || undefined,
+      senderObject.id = event.id || undefined,
+      senderObject.retry = event.retry || undefined
   }
 
   if (typeof event != 'object' && arguments.length === 1) {
-    senderObject.event   = undefined;
-    senderObject.data    = event;
+    senderObject.event = undefined;
+    senderObject.data = event;
   }
 
   if (senderObject.event) this.res.write('event: ' + senderObject.event + '\n');
@@ -55,11 +76,11 @@ SSEClient.prototype.send = function(event, data, id) {
 
   for (var i = 0, l = dataLines.length; i < l; ++i) {
     var line = dataLines[i];
-    if ((i+1) === l) this.res.write('data: ' + line + '\n\n');
+    if ((i + 1) === l) this.res.write('data: ' + line + '\n\n');
     else this.res.write('data: ' + line + '\n');
   }
 }
 
-SSEClient.prototype.close = function() {
+SSEClient.prototype.close = function () {
   this.res.end();
 }

--- a/lib/sseclient.js
+++ b/lib/sseclient.js
@@ -21,6 +21,7 @@ module.exports = SSEClient;
 function SSEClient(req, res, options) {
   this.req = req;
   this.res = res;
+  this.options = options;
   var self = this;
   res.on('close', function () {
     self.emit('close');

--- a/lib/sseclient.js
+++ b/lib/sseclient.js
@@ -36,7 +36,7 @@ SSEClient.prototype.initialize = function () {
   // Merge extra headers with default ones.
   var headers = Object.assign({
     'Content-Type': 'text/event-stream',
-    'Cache-Control': 'no-cache',
+    'Cache-Control': 'no-cache, no-transform',
     'Connection': 'keep-alive'
   },
     this.options.headers

--- a/lib/sseclient.js
+++ b/lib/sseclient.js
@@ -11,7 +11,7 @@ module.exports = SSEClient;
  * @param {Object} options.headers: Extra headers to add to the SSE response.
  *                 The defaults are: {
  *                   'Content-Type': 'text/event-stream',
- *                   'Cache-Control': 'no-cache',
+ *                   'Cache-Control': 'no-cache, no-transform',
  *                   'Connection': 'keep-alive'
  *                 }
  *                 Anything passed in options.headers will be merged over the defaults.


### PR DESCRIPTION
This change allows to add response headers from SSE constructor like this:

`
var sse = new SSE(server, {
  headers: {
    'Access-Control-Allow-Origin': '*',
    "Access-Control-Allow-Headers": "Origin, X-Requested-With, Content-Type, Accept, x-access-token",
    "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS"
  }
});
`